### PR TITLE
Upgrade `cryptography` & `PyJWT`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==1.15.0
 chardet==4.0.0
 click==8.0.3
 croniter==1.0.15
-cryptography==3.4.6
+cryptography==36.0.1
 cycler==0.10.0
 defusedxml==0.7.1
 Django==3.2.12
@@ -41,7 +41,7 @@ pybrake==1.0.4
 pycodestyle==2.8.0
 pycparser==2.20
 pyflakes==2.4.0
-PyJWT==2.0.1
+PyJWT==2.3.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 python-dotenv==0.15.0


### PR DESCRIPTION
Previously we couldn't upgrade `cryptography` because `PyJWT` depended upon an old version of `cryptography`.

By upgrading `PyJWT` we remove that version conflict.